### PR TITLE
[feat/#37] refresh token 재발급

### DIFF
--- a/app/auth/setupApiAuth.ts
+++ b/app/auth/setupApiAuth.ts
@@ -1,6 +1,14 @@
+// app/auth/setupApiAuth.ts
 import { api } from "../lib/api";
 import { tokenStore } from "./tokenStore";
+import { refreshAccessToken, logout } from "../lib/api/user";
 
+let isRefreshing = false;
+let waiters: Array<(t: string | null) => void> = [];
+
+const wakeAll = (t: string | null) => { waiters.forEach(w => w(t)); waiters = []; };
+
+// 요청 시 액세스 토큰 부착
 api.interceptors.request.use(async (cfg) => {
   const token = await tokenStore.get();
   if (token) {
@@ -9,3 +17,44 @@ api.interceptors.request.use(async (cfg) => {
   }
   return cfg;
 });
+
+// 401 응답 처리
+api.interceptors.response.use(
+  (res) => res,
+  async (error) => {
+    const { response, config } = error;
+    const original = config;
+    if (!response) return Promise.reject(error);
+    if ((original as any)._retry) return Promise.reject(error);
+
+    if (response.status === 401) {
+      (original as any)._retry = true;
+
+      if (isRefreshing) {
+        const token = await new Promise<string | null>((resolve) => waiters.push(resolve));
+        if (token) {
+          original.headers = original.headers ?? {};
+          original.headers.Authorization = `Bearer ${token}`;
+        }
+        return api(original);
+      }
+
+      isRefreshing = true;
+      try {
+        const newToken = await refreshAccessToken();
+        wakeAll(newToken);
+        original.headers = original.headers ?? {};
+        original.headers.Authorization = `Bearer ${newToken}`;
+        return api(original);
+      } catch (e) {
+        wakeAll(null);
+        await logout();
+        if (typeof window !== "undefined") window.location.href = "/(login)";
+        return Promise.reject(e);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+    return Promise.reject(error);
+  }
+);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,19 @@
+// app/index.tsx
+import { Redirect } from "expo-router";
+import { useEffect, useState } from "react";
+import { tokenStore } from "./auth/tokenStore";
+
+export default function Index() {
+  // 목적지 결정 전까지는 null
+  const [dest, setDest] = useState<"/(home)" | "/(login)" | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const t = await tokenStore.get();
+      setDest(t ? "/(home)" : "/(login)");
+    })();
+  }, []);
+
+  if (dest === null) return null; // 로딩/스플래시 넣고 싶으면 여기에 UI
+  return <Redirect href={dest} />;
+}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1,3 +1,4 @@
+//lib/api.ts
 import axios from "axios";
 
 export const api = axios.create({

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "axios": "^1.11.0",
         "base-64": "^1.0.0",
         "expo": "~53.0.13",
-        "expo-auth-session": "^6.2.1",
+        "expo-auth-session": "~6.2.1",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.6",
         "expo-dev-client": "~5.2.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "axios": "^1.11.0",
     "base-64": "^1.0.0",
     "expo": "~53.0.13",
-    "expo-auth-session": "^6.2.1",
+    "expo-auth-session": "~6.2.1",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.6",
     "expo-dev-client": "~5.2.2",


### PR DESCRIPTION
## 💡 관련 이슈

#37 

Closes #{이슈번호}

## 💼 작업 설명

- refresh token 기반 access token 자동 갱신 연동

- access token 만료 시 새로운 토큰 발급 확인

- 토큰 만료 또는 에러 시 로그인 페이지로 이동 처리

## ✅ 구현/변경사항

- 로그인 후 access token 저장 로직 통합

- refresh token 요청 시 자동 갱신 가능

## 📝 리뷰 요구사항

- refresh token 기반 access token 재발급 정상 동작
