### PR TITLE
[feat/#44] 상품 등록 카테고리 변경

### DIFF
--- a/app/components/molecules/CategoryDropdown/index.tsx
+++ b/app/components/molecules/CategoryDropdown/index.tsx
@@ -21,12 +21,12 @@ interface CategoryDropdownProps {
 }
 
 const categories = [
-  { label: "IT, 전자제품", value: "ELECTRONICS" },
-  { label: "가구, 인테리어", value: "FURNITURE" },
-  { label: "옷, 잡화, 장신구", value: "CLOTHES" },
-  { label: "도서, 학습 용품", value: "BOOK" },
-  { label: "헤어, 뷰티, 화장품", value: "BEAUTY" },
-  { label: "음식, 식료품", value: "FOOD" },
+  { label: "이동·안전장비", value: "TRAVEL" },
+  { label: "식사·수유·위생 가전", value: "FEEDING" },
+  { label: "수면·안전", value: "SLEEP" },
+  { label: "놀이·교육", value: "PLAY" },
+  { label: "리빙·가구", value: "LIVING" },
+  { label: "의류·잡화", value: "APPAREL" },
   { label: "기타", value: "ETC" },
 ];
 


### PR DESCRIPTION
## 💡 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

Closes #44 

## 💼 작업 설명

백엔드 상품 등록 스펙 변경에 맞춰 폼데이터 구조(json + images[]) 및 카테고리/이미지 유효성을 반영하고, 
multipart 전송 안정성을 개선했습니다

## ✅ 구현/변경사항

- 카테고리 enum 반영: TRAVEL|FEEDING|SLEEP|PLAY|LIVING|APPAREL|OTHER
- 유효성 가드: 대표 이미지 최소 1장, 최대 5장 클라이언트에서 사전 검증

## 📝 리뷰 요구사항

한글→enum 카테고리 매핑 표에 누락/오타 없는지 검토 부탁드립니다.
