### PR TITLE
[feat/#41] 카테고리 조회 및 상세페이지 연결

### DIFF
--- a/app/(category)/[slug].tsx
+++ b/app/(category)/[slug].tsx
@@ -14,9 +14,9 @@ export default function CategoryGridScreen() {
     CATEGORIES.find((c) => c.slug === "OTHER")!;
 
   const {
-    sort,            
-    setSort,         
-    items,           
+    sort,
+    setSort,
+    items,
     loading,
     error,
     refresh,
@@ -38,7 +38,7 @@ export default function CategoryGridScreen() {
       onPressProduct={(id) =>
         router.push({
           pathname: "/(addProduct)/detail",
-          params: { id: String(id) },
+          params: { productId: String(id) }, 
         })
       }
     />


### PR DESCRIPTION
## 💡 관련 이슈

Closes #41 
## 💼 작업 설명

카테고리 페이지에서 상품을 최신순/인기순으로 조회할 수 있도록 정렬 기능을 연동하고,  
상품 클릭 시 상세 페이지로 이동할 수 있도록 경로 설정을 추가했습니다.

## ✅ 구현/변경사항

- `useCategoryProducts` 훅을 활용하여 최신순/인기순 정렬 연동
- `ProductGrid`에 정렬 상태 및 변경 핸들러 전달
- 카테고리 slug에 따라 상품 목록 조회 처리
- 상품 클릭 시 상세 페이지(`/detail`) 경로 이동 설정 (`router.push`)


## 📝 리뷰 요구사항

- 정렬 방식(`new`, `popular`) 처리 로직이 직관적인지 확인 부탁드립니다.  
- 상세 페이지 경로(`/detail`) 네이밍 및 구조가 적절한지 의견 부탁드립니다.
