### PR TITLE
[feat/#10] 상품 검색 페이지와 상품 검색 결과 페이지 구현

### DIFF
--- a/app/(home)/index.tsx
+++ b/app/(home)/index.tsx
@@ -62,6 +62,13 @@ export default function HomeScreen() {
     else router.push('/(addProduct)');
   }, []);
 
+  const goSearch = () => {
+  // (productSearch)/index.tsx 로 이동
+  // 폴더가 app/(productSearch)/index.tsx 라면 아래 둘 중 하나로 이동 가능
+  router.push("/(productSearch)");          // 폴더 인덱스
+  // 또는 라우트 별칭이 /product/search 라면: router.push("/product/search");
+  };
+
 
   // 상세 조회
   const handlePressProduct = useCallback(
@@ -119,7 +126,7 @@ export default function HomeScreen() {
           contentContainerStyle={{ paddingBottom: 12 }} // 탭바와 살짝 간격
           showsVerticalScrollIndicator={false}
         >
-          <SearchBar />
+          <SearchBar onTrigger={goSearch} />
           <RegisterItemButton
             variant="registerItem"
             text="내 물품 등록하기"

--- a/app/(productSearch)/[keyword].tsx
+++ b/app/(productSearch)/[keyword].tsx
@@ -1,0 +1,153 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { SafeAreaView, View, ActivityIndicator, StyleSheet, Text, ImageSourcePropType, Platform, StatusBar } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { ProductGrid } from "../components/organisms/ProductGrid";
+import type { ProductItem } from "../components/molecules/ProductCard"
+import { SearchBar } from "react-native-screens";
+import BottomTabBar from '../components/molecules/BottomTabBar'; 
+
+type SortKey = "new" | "popular";
+const PHONE_WIDTH = 390;
+
+export default function KeywordResultScreen() {
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState('home');
+  const { keyword: _keyword } = useLocalSearchParams<{ keyword?: string }>();
+  const keyword = useMemo(() => String(_keyword ?? ""), [_keyword]);
+
+  const [sort, setSort] = useState<SortKey>("new");
+  const [loading, setLoading] = useState(false);
+  const [products, setProducts] = useState<ProductItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const onTabPress = (tab: string) => {
+    setActiveTab(tab);
+    // 필요하면 라우팅 연결
+    // if (tab === 'profile') router.push('/(me)');
+  };
+
+  // TODO: 실제 아이콘 이미지 경로로 교체
+//   const iconSource = useMemo<ImageSourcePropType>(
+//     () => require("../../../assets/icons/search.png"),
+//     []
+//   );
+
+  const fetchProducts = useCallback(async () => {
+    if (!keyword.trim()) return;
+    try {
+      setLoading(true);
+      setError(null);
+
+      // TODO: 실제 API로 교체하세요.
+      // 예: const res = await fetch(`${API}/products?keyword=${encodeURIComponent(keyword)}&sort=${sort}`);
+      // const data = await res.json();
+
+      // 데모용 목업 데이터
+      const mock: ProductItem[] = Array.from({ length: 12 }).map((_, i) => ({
+        id: i + 1,
+        title: `${keyword} 상품명 ABCDE`,
+        price: 99000,
+        // ProductCard에서 요구하는 필드를 맞춰주세요.
+        // 예: thumbnail: "https://picsum.photos/seed/"+(i+1)+"/300/300"
+        thumbnail: undefined,
+      }));
+
+      // 정렬 데모 (서버가 정렬해 주면 불필요)
+      const sorted =
+        sort === "popular"
+          ? mock.slice().reverse()
+          : mock;
+
+      setProducts(sorted);
+    } catch (e: any) {
+      setError(e?.message ?? "알 수 없는 오류");
+    } finally {
+      setLoading(false);
+    }
+  }, [keyword, sort]);
+
+  useEffect(() => {
+    fetchProducts();
+  }, [fetchProducts]);
+
+  const handleChangeSort = useCallback((s: SortKey) => {
+    setSort(s);
+    // 서버 정렬이면 여기서만 상태 바꾸고 fetchProducts에서 반영
+  }, []);
+
+  const handlePressProduct = useCallback((id: number) => {
+    // 상품 상세로 이동
+    router.push({ pathname: "/product/[id]", params: { id: String(id) } });
+  }, [router]);
+
+  if (!keyword.trim()) {
+    return (
+      <SafeAreaView style={styles.webRoot}>
+        <View style={styles.center}>
+          <Text>검색어가 비어 있습니다.</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <View style={styles.webRoot}>
+      <SafeAreaView style={styles.phoneFrame}>
+        <StatusBar barStyle="dark-content" />
+            {loading && products.length === 0 ? (
+              <View style={styles.center}>
+                <ActivityIndicator />
+              </View>
+            ) : error ? (
+              <View style={styles.center}>
+                <Text>오류가 발생했어요: {error}</Text>
+              </View>
+            ) : products.length === 0 ? (
+              <View style={styles.center}>
+                <Text>‘{keyword}’에 대한 결과가 없어요.</Text>
+              </View>
+            ) : (
+                <>
+              <SearchBar/>
+
+              <ProductGrid
+              //   title={keyword}                 // 헤더 타이틀에 검색어 표시
+              //   iconSource={iconSource}         // 상단 아이콘
+              sort={sort}                     // 현재 정렬 상태
+              onChangeSort={handleChangeSort} // 탭 전환 시
+              products={products}             // 목록 데이터
+              onPressProduct={handlePressProduct}
+              />
+              </>
+            )}
+            
+            
+        <BottomTabBar activeTab={activeTab} onTabPress={onTabPress} />
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  webRoot: {
+      flex: 1,
+      backgroundColor: Platform.OS === 'web' ? '#F5F6F7' : '#fff',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+    },
+    phoneFrame: {
+      flex: 1,
+      backgroundColor: '#fff',
+      maxWidth: Platform.OS === 'web' ? PHONE_WIDTH : undefined,
+      width: Platform.OS === 'web' ? PHONE_WIDTH : undefined,
+      alignSelf: 'center',
+      borderRadius: Platform.OS === 'web' ? 24 : 0,
+      shadowColor: '#000',
+      shadowOpacity: 0.08,
+      shadowRadius: 12,
+      shadowOffset: { width: 0, height: 4 },
+      overflow: Platform.OS === 'web' ? 'hidden' : 'visible',
+    },
+  root: { flex: 1, backgroundColor: "#fff" },
+  center: { flex: 1, justifyContent: "center", alignItems: "center" },
+});

--- a/app/(productSearch)/index.tsx
+++ b/app/(productSearch)/index.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback, useState } from 'react';
+import { SafeAreaView, ScrollView, StatusBar, View, StyleSheet, Platform, ActivityIndicator,
+  Text, } from 'react-native';
+import { useRouter } from 'expo-router';
+import { SearchBar } from '../components/atoms/SearchBar';
+import SearchHistoryList from '../components/molecules/SearchHistoryList'
+import BottomTabBar from '../components/molecules/BottomTabBar';   // 하단 탭바
+
+
+const PHONE_WIDTH = 390;
+
+export default function ProductSearchScreen() {
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState('home');
+  const [query, setQuery] = useState("");
+  const [histories, setHistories] = useState<string[]>(["유모차", "카시트", "아기띠"]);
+
+  const onTabPress = (tab: string) => {
+    setActiveTab(tab);
+    // 필요하면 라우팅 연결
+    // if (tab === 'profile') router.push('/(me)');
+  };
+
+  // 검색 실행 (아이콘/엔터)
+  const onSubmitSearch = useCallback(() => {
+    if (!query.trim()) return;
+    // 최근 검색어에 추가 (중복 제거)
+    setHistories((prev) => [query.trim(), ...prev.filter((v) => v !== query.trim())]);
+    router.push({
+      pathname: "/(productSearch)/[keyword]",
+      params: { keyword: query.trim() },
+    });
+  }, [query, router]);
+
+  // 리스트 아이템 탭 (검색어 눌렀을 때)
+  const onPressKeyword = useCallback((kw: string) => {
+    setQuery(kw);
+    router.push({
+      pathname: "/(productSearch)/[keyword]",
+      params: { keyword: kw },
+    });
+  }, [router]);
+
+  // 리스트 아이템 삭제 (X 아이콘)
+  const onPressDelete = useCallback((kw: string) => {
+    setHistories((prev) => prev.filter((v) => v !== kw));
+  }, []);
+
+  // 모두 삭제
+  const onClearAll = useCallback(() => setHistories([]), []);
+
+  return (
+    <View style={styles.webRoot}>
+      <SafeAreaView style={styles.phoneFrame}>
+        <StatusBar barStyle="dark-content" />
+
+        {/* 스크롤 영역 */}
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingBottom: 12}} // 탭바와 살짝 간격
+          showsVerticalScrollIndicator={false}
+        >
+          <SearchBar
+            value={query}
+            onChangeText={setQuery}
+            onSubmit={onSubmitSearch}
+          />
+          <SearchHistoryList
+            histories={histories}
+            onSelect={onPressKeyword}
+            onRemove={onPressDelete}
+            onClearAll={onClearAll}
+          />
+          
+        </ScrollView>
+
+        {/* 고정 하단 탭바 (스크롤 밖) */}
+        <BottomTabBar activeTab={activeTab} onTabPress={onTabPress} />
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  webRoot: {
+    flex: 1,
+    backgroundColor: Platform.OS === 'web' ? '#F5F6F7' : '#fff',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+  },
+  phoneFrame: {
+    flex: 1,
+    backgroundColor: '#fff',
+    maxWidth: Platform.OS === 'web' ? PHONE_WIDTH : undefined,
+    width: Platform.OS === 'web' ? PHONE_WIDTH : undefined,
+    alignSelf: 'center',
+    borderRadius: Platform.OS === 'web' ? 24 : 0,
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    overflow: Platform.OS === 'web' ? 'hidden' : 'visible',
+  },
+});

--- a/app/components/atoms/SearchBar/index.tsx
+++ b/app/components/atoms/SearchBar/index.tsx
@@ -1,17 +1,46 @@
 import React from 'react';
-import { View, TextInput, StyleSheet } from 'react-native';
+import { View, TextInput, StyleSheet, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
-export const SearchBar = () => (
-  <View style={styles.wrapper}>
-    <View style={styles.container}>
-      <TextInput
-        style={styles.input}
-      />
-      <Ionicons name="search" size={20} color="#999" />
+type Props = {
+  value?: string;
+  onChangeText?: (t: string) => void;
+  onSubmit?: () => void; // 엔터/아이콘 클릭 시 실행
+
+  onTrigger?: () => void;
+};
+
+export const SearchBar = ({ 
+  value, 
+  onChangeText, 
+  onSubmit,
+  onTrigger, 
+}: Props) => {
+  if (onTrigger) {
+    return (
+      <View style={styles.wrapper}>
+        <Pressable style={styles.container} onPress={onTrigger} hitSlop={8}>
+          <Ionicons name="search" size={20} color="#999" />
+        </Pressable>
+      </View>
+    );
+  }
+
+  return(
+    <View style={styles.wrapper}>
+      <View style={styles.container}>
+        <TextInput
+          style={styles.input}
+          value={value}
+          onChangeText={onChangeText}
+          returnKeyType="search"
+          onSubmitEditing={onSubmit}
+        />
+        <Ionicons name="search" size={20} color="#999" onPress={onSubmit}/>
+      </View>
     </View>
-  </View>
-);
+  )
+  };
 
 const styles = StyleSheet.create({
   wrapper: {

--- a/app/components/atoms/SearchKeyword/index.tsx
+++ b/app/components/atoms/SearchKeyword/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+interface SearchKeywordProps {
+  text: string;
+  onPressDelete: () => void;
+  onPressKeyword: () => void;
+}
+
+export const SearchKeyword = ({
+  text,
+  onPressDelete,
+  onPressKeyword,
+}: SearchKeywordProps) =>  (
+  <View style={styles.wrapper}>
+    <View style={styles.container}>
+        <Pressable onPress={onPressKeyword}>
+          <Text
+            style={styles.keyword}
+          >{ text }</Text>
+        </Pressable>
+
+        <Pressable onPress={onPressDelete} hitSlop={8}>
+          <Ionicons name="close-circle" size={18} color="rgba(60,60,67,0.6)" style={{ marginLeft: 'auto' }}/>
+        </Pressable>
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  wrapper: {
+    alignItems: 'center', // 수평 중앙 정렬
+    marginTop: 12,
+    marginLeft: 20,
+    marginRight: 20,
+  },
+  container: {
+    flexDirection: 'row',        // display:flex는 기본값, 대신 방향 지정
+    height: 40,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    alignSelf: 'stretch',
+
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(0,0,0,0.15)',
+  },
+  keyword: {
+    overflow: "hidden",
+    color: "#000",
+    fontFamily: "SF Pro",       
+    fontSize: 15,
+    fontStyle: "normal",
+    fontWeight: "400",
+    lineHeight: 22,
+    letterSpacing: -0.43,
+  }
+});

--- a/app/components/molecules/SearchHistoryList/index.tsx
+++ b/app/components/molecules/SearchHistoryList/index.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { View, Text, StyleSheet, Pressable, FlatList } from "react-native";
+import { SearchKeyword } from "../../atoms/SearchKeyword";
+
+interface SearchHistoryListProps {
+    histories : string[];
+    onSelect: (kw: string) => void;
+    onRemove: (kw: string) => void;
+    onClearAll: () => void;
+}
+
+export default function SearchHistoryList({
+    histories,
+    onSelect,
+    onRemove,
+    onClearAll
+}: SearchHistoryListProps){
+    return (
+    <View style={styles.wrap}>
+      <View style={styles.container}>
+        <Text style={styles.title}>최근 검색어</Text>
+        <Pressable onPress={onClearAll} hitSlop={8}>
+          <Text style={styles.delte}>모두 삭제</Text>
+        </Pressable>
+      </View>
+
+      <FlatList
+        data={histories}
+        keyExtractor={(item, idx) => `${item}-${idx}`}
+        renderItem={({ item }) => (
+          <SearchKeyword
+            text={item}
+            onPressKeyword={() => onSelect(item)}
+            onPressDelete={() => onRemove(item)}
+          />
+        )}
+        ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    color: "#000",
+    fontSize: 15,
+    fontStyle: "normal",
+    fontWeight: "500",
+    lineHeight: 21,
+    letterSpacing: -0.32,
+  },
+  delte: {
+    color: "rgba(0, 0, 0, 0.60)",
+    fontSize: 13,
+    fontStyle: "normal",
+    fontWeight: "100",
+    lineHeight: 21,
+    letterSpacing: -0.32,
+  },
+  container: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    width: 345,
+    marginHorizontal: "auto",
+  },
+  wrap: {
+    marginTop: 29,
+  }
+});

--- a/app/components/organisms/ProductGrid.tsx
+++ b/app/components/organisms/ProductGrid.tsx
@@ -7,8 +7,8 @@ import type { ProductItem } from "../molecules/ProductCard"
 type SortKey = "new" | "popular";
 
 type Props = {
-  title: string;
-  iconSource: ImageSourcePropType; 
+  title?: string;
+  iconSource?: ImageSourcePropType; 
   sort: SortKey;
   onChangeSort: (s: SortKey) => void;
   products: ProductItem[]; 
@@ -18,11 +18,15 @@ type Props = {
 export function ProductGrid({
   title, iconSource, sort, onChangeSort, products, onPressProduct
 }: Props) {
+  const showHeader = !!title || !!iconSource;
+  
   return (
     <View style={s.container}>
       <View style={s.header}>
-        <Image source={iconSource} style={{ width: 40, height: 40, marginRight: 8 }} />
-        <Text style={s.title}>{title}</Text>
+        {iconSource && (
+          <Image source={iconSource} style={{ width: 40, height: 40, marginRight: 8 }} />
+        )}
+        {title && <Text style={s.title}>{title}</Text>}
       </View>
 
       <View style={s.tabsWrap}>


### PR DESCRIPTION
## 💡 관련 이슈
Closes #10 

## 💼 작업 설명
* 홈 화면에서 SearchBar 클릭 시 상품 검색 페이지로 이동하도록 구현했습니다.
* 상품 검색 페이지에서는 최근 검색어를 조회할 수 있으며, 선택 삭제 및 전체 삭제 기능을 지원합니다.
* 키워드 클릭 또는 SearchBar에 키워드 입력 후 검색 아이콘 클릭 시, 최신순 / 인기순으로 상품 목록을 조회할 수 있습니다.

## ✅ 구현/변경사항

https://github.com/user-attachments/assets/bc679741-d473-4f7e-a8e3-c55ac1407af6

## 📝 리뷰 요구사항
상품 검색 페이지 전체 기능에 대해 구조, 상태 관리, 흐름 위주로 코드 리뷰 부탁드립니다.