### PR TITLE
[feat/#53] 토스페이먼츠 결제 승인 전

### DIFF
--- a/.env
+++ b/.env
@@ -12,5 +12,5 @@ EXPO_PUBLIC_API_BASE=http://localhost:8000
 EXPO_PUBLIC_TOSS_CLIENT_KEY=test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm
 
 # 웹(Expo Web: 19006)에서 보여줄 라우트로 변경
-EXPO_PUBLIC_TOSS_SUCCESS_URL=http://localhost:19006/payments/success
-EXPO_PUBLIC_TOSS_FAIL_URL=http://localhost:19006/payments/fail
+#EXPO_PUBLIC_TOSS_SUCCESS_URL=http://localhost:8081/success
+#EXPO_PUBLIC_TOSS_FAIL_URL=http://localhost:8081/fail

--- a/app/(payment)/index.tsx
+++ b/app/(payment)/index.tsx
@@ -72,7 +72,7 @@ export default function PaymentScreen() {
               <OrderInfo
                 title={product.title}
                 price={product.price}
-                shippingFee={0} // 서버에 배송비 있으면 넣어줘
+                shippingFee={0} 
                 image={
                   product.images?.[0]?.imageUrl
                     ? { uri: product.images[0].imageUrl }

--- a/app/(payment)/success.tsx
+++ b/app/(payment)/success.tsx
@@ -1,0 +1,52 @@
+// app/payments/success.tsx
+import React, { useEffect } from "react";
+import { View, ActivityIndicator, Alert } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useConfirmPayment } from "../hooks/useConfirmPayment";
+
+export default function PaymentSuccess() {
+  const router = useRouter();
+  const { paymentKey, orderId, amount, tradeId } = useLocalSearchParams<{
+    paymentKey?: string;
+    orderId?: string;
+    amount?: string;
+    tradeId?: string; // 우리가 successUrl에 붙여 보낸 값
+  }>();
+
+  const { mutateAsync, isPending } = useConfirmPayment();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (!paymentKey || !orderId || !amount || !tradeId) {
+          Alert.alert("결제 승인 불가", "필수 파라미터가 없습니다.");
+          return;
+        }
+
+        const res = await mutateAsync({
+          paymentKey,
+          orderId,
+          amount: Number(amount),
+          tradeId: Number(tradeId),
+        });
+
+        const chatroomId = res.data?.chatroomId;
+        if (!chatroomId) {
+          Alert.alert("처리 완료", "결제는 승인되었지만 채팅방 정보를 찾을 수 없습니다.");
+          router.replace("/chat"); // 목록 등 안전한 경로
+          return;
+        }
+
+        router.replace(`/chat/${chatroomId}`);
+      } catch (e: any) {
+        Alert.alert("결제 승인 실패", String(e?.message ?? e));
+      }
+    })();
+  }, [paymentKey, orderId, amount, tradeId, mutateAsync, router]);
+
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+      <ActivityIndicator />
+    </View>
+  );
+}

--- a/app/components/organisms/PaymentWidget.web.tsx
+++ b/app/components/organisms/PaymentWidget.web.tsx
@@ -1,3 +1,4 @@
+// app/components/organisms/PaymentWidget.web.tsx
 import React, { useEffect, useRef, useState } from "react";
 import {
   View,
@@ -10,15 +11,14 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTempSavePayment } from "../../hooks/useTempSavePayment";
-import { useVerifyPayment } from "../../hooks/useVerifyPayment";
 
 type Props = {
-  amount?: number;               // 결제 금액(원)
-  customerKey?: string;          // 고객 식별자
-  orderId?: string;              // 주문번호(없으면 내부에서 생성하여 고정)
-  orderName?: string;            // 주문명
-  successUrl?: string;           // 결제 성공 리다이렉트 URL
-  failUrl?: string;              // 결제 실패/취소 리다이렉트 URL
+  amount?: number;        // 결제 금액(원)
+  customerKey?: string;   // 고객 식별자
+  orderId?: string;       // 주문번호(없으면 내부에서 생성하여 고정)
+  orderName?: string;     // 주문명
+  successUrl?: string;    // 결제 성공 리다이렉트 URL
+  failUrl?: string;       // 결제 실패/취소 리다이렉트 URL
 };
 
 const PRIMARY = "#0F5965";
@@ -28,8 +28,6 @@ export default function PaymentWidget({
   customerKey = "customer_123",
   orderId,
   orderName = "피키 유아용품",
-  successUrl = process.env.EXPO_PUBLIC_TOSS_SUCCESS_URL ?? `${location.origin}/payments/success`,
-  failUrl = process.env.EXPO_PUBLIC_TOSS_FAIL_URL ?? `${location.origin}/payments/fail`,
 }: Props) {
   // 웹이 아니면 렌더하지 않음
   if (Platform.OS !== "web") return null;
@@ -39,17 +37,21 @@ export default function PaymentWidget({
 
   const clientKey = process.env.EXPO_PUBLIC_TOSS_CLIENT_KEY;
 
-  // ✅ API 베이스 URL (여러 키 지원)
+  // API 베이스 URL (여러 키 지원)
   const apiBaseUrl =
     process.env.EXPO_PUBLIC_API_BASE_URL ??
     process.env.EXPO_PUBLIC_API_URL ??
     process.env.EXPO_PUBLIC_API_BASE;
+  // PaymentWidget.web.tsx
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const successUrl = process.env.EXPO_PUBLIC_TOSS_SUCCESS_URL ?? `${origin}/success`;
+  const failUrl = process.env.EXPO_PUBLIC_TOSS_FAIL_URL ?? `${origin}/fail`;
 
-  // ✅ 임시 저장 / 검증 훅
-  const { mutateAsync: tempSave, loading: saving } = useTempSavePayment({ baseUrl: apiBaseUrl });
-  const { mutateAsync: verify, loading: verifying } = useVerifyPayment({ baseUrl: apiBaseUrl });
 
-  // ✅ orderId는 최초 한 번만 생성/고정
+  // temp-save 훅
+  const { mutateAsync: tempSave } = useTempSavePayment({ baseUrl: apiBaseUrl });
+
+  // orderId는 최초 한 번만 생성/고정
   const orderRef = useRef<string>(orderId ?? `ORDER-${Date.now()}`);
 
   const methodsId = "toss-payment-methods";
@@ -61,23 +63,19 @@ export default function PaymentWidget({
   const [ready, setReady] = useState(false);
   const [loading, setLoading] = useState(true);
 
-  // 최초 로딩: 위젯 로드 + 렌더
+  // 위젯 로드 + 렌더
   useEffect(() => {
     let mounted = true;
-
     (async () => {
       try {
         if (!clientKey) throw new Error("EXPO_PUBLIC_TOSS_CLIENT_KEY 가 설정되지 않았습니다.");
 
         const { loadPaymentWidget } = await import("@tosspayments/payment-widget-sdk");
 
-        // ✅ DOM이 실제로 붙은 다음 실행(한 프레임 대기)
+        // 한 프레임 대기하여 DOM 보장
         await new Promise((r) => requestAnimationFrame(() => r(null)));
 
-        // ✅ RN Web에서 id가 보장되도록 강제로 DOM id도 지정해두는 게 안전
-        const methodsEl = document.querySelector(`#${methodsId}`);
-        const agreementEl = document.querySelector(`#${agreementId}`);
-        if (!methodsEl || !agreementEl) {
+        if (!document.querySelector(`#${methodsId}`) || !document.querySelector(`#${agreementId}`)) {
           throw new Error("결제 컨테이너 DOM(#toss-payment-*)를 찾지 못했습니다.");
         }
 
@@ -112,7 +110,7 @@ export default function PaymentWidget({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clientKey, customerKey]);
 
-  // 금액 변경 시 위젯 금액 업데이트 (updateAmount가 Promise 아닐 수 있어 안전 처리)
+  // 금액 변경 시 위젯 금액 업데이트
   useEffect(() => {
     if (!pmControl) return;
     try {
@@ -120,54 +118,38 @@ export default function PaymentWidget({
       if (ret && typeof (ret as any).catch === "function") {
         (ret as any).catch((e: any) => console.warn("updateAmount error:", e));
       }
-      // 또는: Promise.resolve(ret).catch(...)
     } catch (e) {
       console.warn("updateAmount threw:", e);
     }
   }, [amount, pmControl]);
 
-  const handleRequestPay = async () => {
-    try {
-      if (!paymentWidgetRef.current || !agControl) {
-        Alert.alert("주문 정보가 초기화되지 않았습니다.");
-        return;
-      }
+  // 페이지 로드/금액 변경 시 서버에 "임시 저장" (fire & forget)
+  useEffect(() => {
+    const oid = orderRef.current;
+    const amt = Number(amount ?? 0);
+    if (!oid || !amt) return;
+    tempSave({ orderId: oid, amount: amt }).catch((e) => {
+      console.warn("tempSave failed:", e);
+    });
+  }, [amount, tempSave]);
 
-      const agreement = await agControl.getAgreementStatus();
-      if (!agreement?.agreedRequiredTerms) {
-        Alert.alert("약관에 동의하지 않았습니다.");
-        return;
-      }
+  // 버튼 클릭 시엔 즉시 결제 요청만 호출 (user gesture 유지)
+  const handleRequestPay = () => {
 
-      const resolvedOrderId = orderRef.current;     // ✅ temp-save/verify 동일 값 사용
-      const amt = Number(amount ?? 0);              // ✅ 숫자 보장
-
-      // 1) 임시 저장
-      await tempSave({ orderId: resolvedOrderId, amount: amt });
-
-      // 2) 검증
-      await verify({ orderId: resolvedOrderId, amount: amt });
-
-      // 3) 결제 요청
-      await paymentWidgetRef.current.requestPayment({
-        orderId: resolvedOrderId,
-        orderName,
-        successUrl,
-        failUrl,
-      });
-    } catch (e: any) {
-      Alert.alert("결제 요청 실패", String(e?.message ?? e));
-    }
-  };
-
-  // (옵션) 디버깅용
-  const handleShowSelected = async () => {
-    if (!pmControl) {
+    if (!paymentWidgetRef.current) {
       Alert.alert("주문 정보가 초기화되지 않았습니다.");
       return;
     }
-    const selected = await pmControl.getSelectedPaymentMethod();
-    Alert.alert(`선택된 결제수단: ${JSON.stringify(selected)}`);
+
+    paymentWidgetRef.current.requestPayment({
+      orderId: orderRef.current,
+      orderName,
+      successUrl,
+      failUrl,
+    })
+      .catch((e: any) => {
+        Alert.alert("결제 요청 실패", String(e?.message ?? e));
+      });
   };
 
   return (
@@ -178,27 +160,24 @@ export default function PaymentWidget({
         </View>
       )}
 
-      {/* ✅ DOM id와 nativeID를 모두 지정 */}
+      {/* RN Web에서 selector 인식 안정화를 위해 id/nativeID 모두 지정 */}
       {/* @ts-ignore */}
       <View id={methodsId} nativeID={methodsId} style={styles.methods} />
       {/* @ts-ignore */}
       <View id={agreementId} nativeID={agreementId} style={styles.agreement} />
 
       <View style={[styles.footer, { paddingBottom: safeBottom }]}>
+        {/* user gesture 유지: disabled는 ready만 기준 */}
         <Pressable
           onPress={handleRequestPay}
-          disabled={!ready || saving || verifying}
+          disabled={!ready}
           style={({ pressed }) => [
             styles.primaryBtn,
-            (!ready || saving || verifying) && { opacity: 0.5 },
+            !ready && { opacity: 0.5 },
             pressed && { transform: [{ translateY: 1 }] },
           ]}
         >
-          {saving || verifying ? (
-            <ActivityIndicator color="#fff" />
-          ) : (
-            <Text style={styles.primaryText}>결제하기</Text>
-          )}
+          <Text style={styles.primaryText}>결제하기</Text>
         </Pressable>
       </View>
 

--- a/app/hooks/useConfirmPayment.ts
+++ b/app/hooks/useConfirmPayment.ts
@@ -1,0 +1,22 @@
+// hooks/useConfirmPayment.ts
+import { useMutation } from "@tanstack/react-query";
+import { confirmPayment, ConfirmPayload, ConfirmResponse } from "../lib/api/payment";
+import { useAccessToken } from "./useAccessToken";
+
+const DEFAULT_BASE =
+  process.env.EXPO_PUBLIC_API_BASE_URL ??
+  process.env.EXPO_PUBLIC_API_URL ??
+  process.env.EXPO_PUBLIC_API_BASE;
+
+export function useConfirmPayment(opts?: { baseUrl?: string }) {
+  const baseUrl = opts?.baseUrl ?? DEFAULT_BASE;
+  const { getAccessToken } = useAccessToken();
+
+  return useMutation<ConfirmResponse, Error, ConfirmPayload>({
+    mutationFn: async (payload) => {
+      const token = await getAccessToken();
+      if (!token) throw new Error("로그인이 필요합니다. (토큰 없음)");
+      return confirmPayment({ payload, token, baseUrl });
+    },
+  });
+}

--- a/app/lib/api/payment.ts
+++ b/app/lib/api/payment.ts
@@ -29,7 +29,7 @@ export async function tempSavePayment({ payload, token, baseUrl }: CommonParams<
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    // ✅ 서버가 세션 쿠키(JSESSIONID 등)를 쓴다면 반드시 포함
+    // 서버가 세션 쿠키(JSESSIONID 등)를 쓴다면 반드시 포함
     credentials: "include",
     mode: "cors",
     body: JSON.stringify(payload),
@@ -49,7 +49,7 @@ export async function verifyPayment({ payload, token, baseUrl }: CommonParams<Ve
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    credentials: "include", // ✅ temp-save와 동일 세션 유지
+    credentials: "include", // temp-save와 동일 세션 유지
     mode: "cors",
     body: JSON.stringify(payload),
   });
@@ -58,3 +58,36 @@ export async function verifyPayment({ payload, token, baseUrl }: CommonParams<Ve
   if (json.code !== 200) throw new Error(json.message ?? "결제 금액 검증 실패");
   return json as VerifyResponse;
 }
+
+// 결제 승인
+export type ConfirmPayload = {
+  tradeId: number;
+  paymentKey: string;
+  amount: number;
+  orderId: string;
+};
+export type ConfirmResponse = { code: number; message: string; data?: { chatroomId?: number }; };
+
+export async function confirmPayment({
+  payload,
+  token,
+  baseUrl,
+}: CommonParams<ConfirmPayload>) {
+  const base = resolveBaseUrl(baseUrl);
+  const res = await fetch(`${base}/payment/confirm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    credentials: "include",
+    mode: "cors",
+    body: JSON.stringify(payload),
+  });
+  const json = await res.json().catch(() => ({} as any));
+  if (!res.ok) throw new Error(json?.message ?? `HTTP ${res.status}`);
+  if (json.code !== 200) throw new Error(json.message ?? "결제 승인 실패");
+  return json as ConfirmResponse;
+}
+
+


### PR DESCRIPTION
## 💡 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

Closes #53 

## 💼 작업 설명

<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->
토스페이먼츠 결제 위젯(Web) 1차 연동 (결제 승인 전 단계까지)

## ✅ 구현/변경사항

<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->
app/components/organisms/PaymentWidget.web.tsx

- 토스 Payment Widget 로드 및 렌더링
- 금액 변경 시 updateAmount 반영

lib/api/payment.ts
hooks/useTempSavePayment.ts, hooks/useVerifyPayment.ts

app/(payment)/index.tsx
- useLocalSearchParams로 productId 수신
- useProductDetail로 상품 상세 조회 → OrderInfo/PaymentWidget에 전달


## 📝 리뷰 요구사항

<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->
