### PR TITLE
[feat/#89] 상대 프로필 UI 구현

### DIFF
--- a/app/(profile)/otherProfile.tsx
+++ b/app/(profile)/otherProfile.tsx
@@ -1,0 +1,128 @@
+import React, { useMemo, useState } from "react";
+import {
+  SafeAreaView,
+  View,
+  Text,
+  StyleSheet,
+  Platform,
+  StatusBar,
+  Image,
+  Pressable,
+} from "react-native";
+import { useRouter } from "expo-router";
+import BottomTabBar from "../components/molecules/BottomTabBar";
+import ProfileCard from "../components/molecules/ProfileCard";
+import OtherProfileContent from "../components/organisms/OtherProfileContent";
+
+const PHONE_WIDTH = 390;
+const BACK_ICON = require("../../assets/images/back.png");
+
+export default function OtherProfileScreen() {
+  const router = useRouter();
+  const [activeTab, setActiveTab] =
+    useState<"notifications" | "chat" | "home" | "community" | "profile">("home");
+
+  const profile = {
+    name: "홍길동",
+    mainCategories: ["IT, 전자제품", "도서, 학습 용품"],
+    trustScore: 70,
+    avatarSource: require("../../assets/images/default-avatar.png"),
+  };
+  const sales = useMemo(
+    () =>
+      Array.from({ length: 8 }).map((_, i) => ({
+        id: i + 1,
+        title: "상품명 ABCDE",
+        price: 99000,
+        imageUrl: "",
+      })),
+    []
+  );
+  const posts = useMemo(
+    () =>
+      Array.from({ length: 6 }).map((_, i) => ({
+        id: 100 + i,
+        title: "게시글 제목 ABCDE",
+        imageUrl: "",
+      })),
+    []
+  );
+
+  return (
+    <View style={s.webRoot}>
+      <SafeAreaView style={s.phoneFrame}>
+        <StatusBar barStyle="dark-content" />
+        <View style={s.header}>
+          <Pressable
+            onPress={() => router.back()}
+            hitSlop={10}
+            style={[s.backBtn, Platform.OS === "web" && ({ cursor: "pointer" } as any)]}
+            accessibilityRole="button"
+            accessibilityLabel="뒤로 가기"
+          >
+            <Image source={BACK_ICON} style={s.backIcon} resizeMode="contain" />
+          </Pressable>
+          <View style={{ width: 24 }} />
+        </View>
+
+        <View style={s.cardWrap}>
+          <ProfileCard
+            name={profile.name}
+            mainCategories={profile.mainCategories}
+            trustScore={profile.trustScore}
+            avatarSource={profile.avatarSource}
+            onPressProfile={() => {}}
+          />
+        </View>
+
+        <OtherProfileContent
+          salesItems={sales}
+          postItems={posts}
+          onPressProduct={(id) =>
+            router.push({ pathname: "/(addProduct)/detail", params: { productId: String(id) } })
+          }
+          onPressPost={(postId) =>
+            router.push({ pathname: "/(community)/post-detail", params: { id: String(postId) } })
+          }
+        />
+
+        <BottomTabBar activeTab={activeTab} onTabPress={(t) => setActiveTab(t as any)} />
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  webRoot: {
+    flex: 1,
+    backgroundColor: Platform.OS === "web" ? "#F5F6F7" : "#fff",
+    alignItems: "center",
+  },
+  phoneFrame: {
+    flex: 1,
+    backgroundColor: "#fff",
+    maxWidth: Platform.OS === "web" ? PHONE_WIDTH : undefined,
+    width: Platform.OS === "web" ? PHONE_WIDTH : undefined,
+    alignSelf: "center",
+    borderRadius: Platform.OS === "web" ? 24 : 0,
+    shadowColor: "#000",
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    overflow: Platform.OS === "web" ? "hidden" : "visible",
+  },
+
+  header: {
+    height: 48,
+    paddingHorizontal: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: "#FFFFFF",
+  },
+  backBtn: { paddingVertical: 6, paddingRight: 6 },
+  backIcon: { width: 16, height: 16 },
+  headerTitle: { fontSize: 18, fontWeight: "700", color: "#111827" },
+
+  cardWrap: { paddingHorizontal: 16, marginTop: 8 },
+});

--- a/app/components/organisms/OtherProfileContent.tsx
+++ b/app/components/organisms/OtherProfileContent.tsx
@@ -1,0 +1,100 @@
+import React, { useMemo, useState } from "react";
+import { View, StyleSheet, Text, ScrollView } from "react-native";
+import { SortTabs } from "../molecules/SortTabs";
+import { TradeProductsGrid } from "./TradeProductsGrid";
+
+type TabKey = "sales" | "posts";
+type ProductItem = { id: number; title: string; price: number; imageUrl?: string };
+type PostItem = { id: number; title: string; imageUrl?: string };
+
+export default function OtherProfileContent({
+  salesItems,
+  postItems,
+  onPressProduct,
+  onPressPost,
+}: {
+  salesItems: ProductItem[];
+  postItems: PostItem[];
+  onPressProduct: (id: number) => void;
+  onPressPost: (id: number) => void;
+}) {
+  const [tab, setTab] = useState<TabKey>("sales");
+  const sortedSales = useMemo(() => salesItems, [salesItems]);
+
+  return (
+    <ScrollView
+      style={s.container}
+      contentContainerStyle={s.content}
+      showsVerticalScrollIndicator={false}
+    >
+      {/* 상단 탭 */}
+      <View style={s.tabsWrap}>
+        <SortTabs<TabKey>
+          value={tab}
+          onChange={setTab}
+          items={[
+            { key: "sales", label: "판매 상품" },
+            { key: "posts", label: "작성한 글" },
+          ]}
+          segmented
+          width={358}
+        />
+      </View>
+
+      {/* 콘텐츠 */}
+      <View style={s.body}>
+        {tab === "sales" ? (
+          <TradeProductsGrid items={sortedSales} onPressItem={onPressProduct} />
+        ) : (
+          <PostsGrid items={postItems} onPressItem={onPressPost} />
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
+function PostsGrid({
+  items,
+  onPressItem,
+}: {
+  items: { id: number; title: string; imageUrl?: string }[];
+  onPressItem: (id: number) => void;
+}) {
+  return (
+    <View style={{ paddingHorizontal: 16, paddingBottom: 8 }}>
+      {items.length === 0 ? (
+        <View style={{ padding: 24, alignItems: "center" }}>
+          <Text>작성한 글이 없습니다.</Text>
+        </View>
+      ) : (
+        items.map((p) => (
+          <View
+            key={p.id}
+            style={{
+              borderWidth: StyleSheet.hairlineWidth,
+              borderColor: "#E5E7EB",
+              borderRadius: 12,
+              padding: 14,
+              marginTop: 12,
+              backgroundColor: "#fff",
+            }}
+            onTouchEnd={() => onPressItem(p.id)}
+          >
+            <Text style={{ fontSize: 15, fontWeight: "600", color: "#111827" }} numberOfLines={2}>
+              {p.title}
+            </Text>
+          </View>
+        ))
+      )}
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { flex: 1 },
+  content: {
+    paddingBottom: 24, 
+  },
+  tabsWrap: { paddingHorizontal: 16, marginTop: 16 },
+  body: { marginTop: 8 },
+});


### PR DESCRIPTION
## 💡 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

Closes #89 

## 💼 작업 설명

<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->
- 상대 프로필 페이지 구현
- ProfileCard, SortTabs, TradeProductsGrid 재사용
- 상세페이지 백버튼 헤더 공통 적용

## ✅ 구현/변경사항

<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->
- app/(profile)/other-profile.tsx 추가
- `OtherProfileContent` Organism 구현 (탭 + 판매상품/작성글 전환)
- ScrollView 적용하여 판매 상품/작성글 스크롤 가능

## 📝 리뷰 요구사항

<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->
