### PR TITLE
[feat/#103] 상품 상세 페이지 거래 상태 반영

### DIFF
--- a/app/(addProduct)/detail.tsx
+++ b/app/(addProduct)/detail.tsx
@@ -42,19 +42,6 @@ const showAlert = (title: string, message?: string) => {
   else Alert.alert(title, message);
 };
 
-function mapStatusKToUI(k?: string): "ON_SALE" | "IN_PROGRESS" | "SOLD_OUT" {
-  switch (k) {
-    case "판매 중":
-      return "ON_SALE";
-    case "예약 중":
-      return "IN_PROGRESS";
-    case "판매 완료":
-      return "SOLD_OUT";
-    default:
-      return "ON_SALE";
-  }
-}
-
 // "2025.08.26" 또는 ISO 문자열 → 사람이 읽기 쉬운 값
 function formatCreatedAt(s?: string): string {
   if (!s) return "";
@@ -95,9 +82,7 @@ function getUserIdFromToken(token: string): number | null {
 
 export default function UnifiedDetailScreen() {
   const router = useRouter();
-  const { productId } = useLocalSearchParams<{
-    productId?: string | string[];
-  }>();
+  const { productId } = useLocalSearchParams<{ productId?: string | string[] }>();
   const id = Number(Array.isArray(productId) ? productId[0] : productId);
 
   const [token, setToken] = useState<string | null>(null);
@@ -146,6 +131,7 @@ function DetailContent({ id, token }: { id: number; token: string }) {
   const [reportOpen, setReportOpen] = useState(false);
   const REPORT_ICON = require("../../assets/images/report.png");
 
+  // 훅이 이미 상태를 표준 코드/라벨로 정규화해서 내려줌
   const { data, isLoading, error, refetch } = useProductDetail(id, token);
   const toggleLike = useToggleLike(id, token);
   const { mutate: deleteProduct } = useDeleteProduct();
@@ -188,12 +174,8 @@ function DetailContent({ id, token }: { id: number; token: string }) {
     .map((img: any) => ({ imageUrl: img?.imageUrl ?? "" }))
     .filter((i: any) => i.imageUrl);
 
-  const priceNum =
-    typeof data.price === "number"
-      ? data.price
-      : Number(String(data.price ?? "0").replace(/[^\d]/g, ""));
-
-  const uiStatus = mapStatusKToUI(data.status as string);
+  // 훅에서 숫자로 정규화되어 옴
+  const priceNum = data.price as number;
 
   const avatar: ImageSourcePropType = data.sellerImageUrl
     ? ({ uri: data.sellerImageUrl } as ImageURISource)
@@ -211,7 +193,9 @@ function DetailContent({ id, token }: { id: number; token: string }) {
       postedAt: formatCreatedAt(data.createdAt),
       avatar,
     },
-    status: uiStatus,
+    // 표준 코드/라벨을 그대로 사용
+    status: data.status, // "SELLING" | "IN_PROGRESS" | "SOLD_OUT"
+    statusLabel: data.statusLabel, // "판매 중" | "예약 중" | "거래 완료"
     liked: Boolean(data.liked),
     likeCount: Number(data.likeCount ?? 0),
   };
@@ -244,20 +228,6 @@ function DetailContent({ id, token }: { id: number; token: string }) {
       },
     });
   };
-
-  // const handleChat = () => {
-  //   if (!sellerId) {
-  //     showAlert("오류", "판매자 정보가 없어 채팅을 시작할 수 없습니다.");
-  //     return;
-  //   }
-  //   // router.push({
-  //   //   pathname: "/(chatroomList)",
-  //   //   params: {
-  //   //     productId: String(id),
-  //   //     receiverId: String(sellerId),
-  //   //   },
-  //   // });
-  // };
 
   return (
     <View style={styles.webRoot}>

--- a/app/hooks/useProductDetail.ts
+++ b/app/hooks/useProductDetail.ts
@@ -4,31 +4,77 @@ import { api } from "../lib/api";
 import { useAccessToken } from "./useAccessToken";
 
 type ApiImage = { productImageId: number; imageUrl: string };
+
 type ServerProduct = {
-  productId: number; sellerId: number; sellerNickname?: string; sellerImageUrl?: string;
-  createdAt?: string; title: string; content: string; price: number | string;
-  category: string; status: string; seller?: boolean; liked?: boolean;
-  likeCount?: number; images: ApiImage[];
+  productId: number;
+  sellerId: number;
+  sellerNickname?: string;
+  sellerImageUrl?: string;
+  createdAt?: string;
+  title: string;
+  content: string;
+  price: number | string;
+  category: string;
+  status: string; // "판매 중" | "예약 중" | "판매 완료"
+  seller?: boolean;
+  liked?: boolean;
+  likeCount?: number;
+  images: ApiImage[];
 };
 
+// 프론트에서 사용하는 표준 타입
 export type ApiProduct = {
-  productId: number; sellerId: number; sellerNickname?: string; sellerImageUrl?: string;
-  createdAt?: string; title: string; content: string; price: number | string;
-  category: string; status: "SELLING" | "IN_PROGRESS" | "SOLD_OUT";
-  seller: boolean; liked: boolean; likeCount: number; images: ApiImage[];
+  productId: number;
+  sellerId: number;
+  sellerNickname?: string;
+  sellerImageUrl?: string;
+  createdAt?: string;
+  title: string;
+  content: string;
+  price: number; // 숫자로 정규화
+  category: string;
+  status: "SELLING" | "IN_PROGRESS" | "SOLD_OUT"; // 로직 분기용
+  statusLabel: string; 
+  seller: boolean;
+  liked: boolean;
+  likeCount: number;
+  images: ApiImage[];
 };
 
 type ApiOk = { code: 200; message: string; data: ServerProduct };
 type ApiNotFound = { code: 404; message: string };
 type ApiResponse = ApiOk | ApiNotFound;
 
-const STATUS_MAP: Record<string, ApiProduct["status"]> = {
-  "판매 중": "SELLING",
-  "거래 중": "IN_PROGRESS",
-  "판매 완료": "SOLD_OUT",
-};
+// "예약 중" / "예약중" / "거래 중" 등 허용
+function normalizeStatusToCode(raw?: string): ApiProduct["status"] {
+  const s = (raw ?? "").replace(/\s/g, "");
+  // 서버가 "거래 중"으로 내려올 가능성도 고려
+  if (s === "판매중") return "SELLING";
+  if (s === "예약중" || s === "거래중") return "IN_PROGRESS";
+  if (s === "판매완료" || s === "거래완료") return "SOLD_OUT";
+  // 모르면 일단 판매중 처리
+  return "SELLING";
+}
+
+function statusCodeToLabel(code: ApiProduct["status"]): string {
+  switch (code) {
+    case "SELLING":
+      return "판매 중";
+    case "IN_PROGRESS":
+      return "예약 중"; 
+    case "SOLD_OUT":
+      return "거래 완료"; 
+  }
+}
+
+function normalizePrice(p: number | string): number {
+  if (typeof p === "number") return p;
+  const n = Number(String(p).replace(/[^\d]/g, ""));
+  return Number.isFinite(n) ? n : 0;
+}
 
 function normalize(server: ServerProduct): ApiProduct {
+  const status = normalizeStatusToCode(server.status);
   return {
     productId: server.productId,
     sellerId: server.sellerId,
@@ -37,9 +83,10 @@ function normalize(server: ServerProduct): ApiProduct {
     createdAt: server.createdAt,
     title: server.title,
     content: server.content,
-    price: server.price,
+    price: normalizePrice(server.price),
     category: server.category,
-    status: STATUS_MAP[server.status] ?? "SELLING",
+    status,
+    statusLabel: statusCodeToLabel(status),
     seller: !!server.seller,
     liked: !!server.liked,
     likeCount: typeof server.likeCount === "number" ? server.likeCount : 0,
@@ -50,7 +97,7 @@ function normalize(server: ServerProduct): ApiProduct {
 async function fetchProductDetail(productId: number, token: string): Promise<ApiProduct> {
   const { data } = await api.get<ApiResponse>(`/product/${productId}`, {
     headers: { Authorization: `Bearer ${token}` },
-    withCredentials: true, // 서버가 세션/쿠키를 쓰면 유지
+    withCredentials: true,
   });
 
   if ("code" in data && data.code === 404) {
@@ -62,11 +109,11 @@ async function fetchProductDetail(productId: number, token: string): Promise<Api
   return normalize(data.data);
 }
 
-export const useProductDetail = (productId: number) => {
+export const useProductDetail = (productId: number, passedToken?: string) => {
   const { getAccessToken } = useAccessToken();
 
   return useQuery<ApiProduct, Error>({
-    queryKey: ["productDetail", productId],
+    queryKey: ["productDetail", productId, Boolean(passedToken)],
     enabled: Number.isFinite(productId) && productId > 0,
     staleTime: 60_000,
     retry: (failures, err) => {
@@ -75,7 +122,7 @@ export const useProductDetail = (productId: number) => {
       return failures < 2;
     },
     queryFn: async () => {
-      const token = await getAccessToken();
+      const token = passedToken || (await getAccessToken());
       if (!token) throw new Error("로그인이 필요합니다. (토큰 없음)");
       return fetchProductDetail(productId, token);
     },

--- a/app/lib/api/product.ts
+++ b/app/lib/api/product.ts
@@ -64,6 +64,7 @@ export const registerProduct = async (formData: FormData, token: string) => {
   return response.data;
 };
 
+//상품 조회
 export const fetchProductDetail = async (productId: number, token: string) => {
   const response = await api.get(
     `/product/${productId}`,


### PR DESCRIPTION
## 💡 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

Closes #{이슈번호}

## 💼 작업 설명

<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->

상품 상세(비작성자) 페이지에서 서버 응답 상태(판매 중/예약 중/판매 완료) 를 프론트 표준 상태(SELLING | IN_PROGRESS | SOLD_OUT)로 설정
## ✅ 구현/변경사항

<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->

hooks/useProductDetail.ts
서버 상태 문자열 → 표준 코드로 매핑: normalizeStatusToCode()
"판매 중", "거래 중"", "거래 완료" 반영

## 📝 리뷰 요구사항

<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->
<img width="360" height="1000" alt="image" src="https://github.com/user-attachments/assets/47186927-450a-4611-9415-68ccbef33e75" />